### PR TITLE
Question - (delete branch after)

### DIFF
--- a/components/atoms/Person/Person.tsx
+++ b/components/atoms/Person/Person.tsx
@@ -3,7 +3,7 @@ import React from "react";
 
 import styles from "./Person.module.css";
 
-export type PersonProps = {
+type PersonProps = {
   name: string;
   role: string;
   pic: string;
@@ -23,4 +23,4 @@ const Person = ({ name, role, pic }: PersonProps) => {
   );
 };
 
-export { Person };
+export { Person, type PersonProps };


### PR DESCRIPTION
Are type exports ever grouped along with the rest of the file's exports?
when not specifying 'type' in the export, it triggers this error (but still compiles?): 
"Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.ts(1205)"